### PR TITLE
Feature: vendor push

### DIFF
--- a/features/environment.feature
+++ b/features/environment.feature
@@ -11,6 +11,7 @@ Scenario:
   When I successfully run `vendor sync`
   And I successfully run `vendor push`
   Then branch "vendor/generated" exists in the remote repo
+  And tag "vendor/generated/0.23" exists in the remote repo
 
 
 

--- a/features/environment.feature
+++ b/features/environment.feature
@@ -1,0 +1,16 @@
+Feature: Environment management.
+
+Scenario:
+  Given a repository with following Vendorfile:
+    """ruby
+    vendor 'generated', :version => '0.23' do |v|
+      File.open('README', 'w') { |f| f.puts "Hello, World!" }
+    end
+    """
+  And a remote repository
+  When I successfully run `vendor sync`
+  And I successfully run `vendor push`
+  Then branch "vendor/generated" exists in the remote repo
+
+
+

--- a/features/step_definitions/basic.rb
+++ b/features/step_definitions/basic.rb
@@ -19,6 +19,17 @@ Given /^a repository with following Vendorfile:$/ do |vendorfile_contents|
   run_simple 'git commit -m "New repo"'
 end
 
+Given /^a remote repository$/ do
+  create_dir '../remote-repository'
+  cd '../remote-repository'
+  run_simple 'git init --bare'
+  # Configure Git username & email to unclutter console output
+  run_simple 'git config user.name Cucumber'
+  run_simple 'git config user.email cucumber@`hostname --fqdn`'
+  cd '../working-repository'
+  run_simple 'git remote add origin ../remote-repository'
+end
+
 When /^I change Vendorfile to:$/ do |vendorfile_contents|
   write_file('Vendorfile', vendorfile_contents)
   run_simple 'git commit -m "Updated Vendorfile" Vendorfile'

--- a/features/step_definitions/git.rb
+++ b/features/step_definitions/git.rb
@@ -45,3 +45,7 @@ end
 Then /^branch "(.*?)" exists in the remote repo$/ do |branch_name|
   assert { remote_git.heads.include?(branch_name) }
 end
+
+Then /^tag "(.*?)" exists in the remote repo$/ do |tag_name|
+  assert { remote_git.tags.include?(tag_name) }
+end

--- a/features/step_definitions/git.rb
+++ b/features/step_definitions/git.rb
@@ -41,3 +41,7 @@ end
 Then(/^there's a git log message including "(.*?)"$/) do |message|
   assert { git.log.lines.any? { |ln| ln.include?(message) } }
 end
+
+Then /^branch "(.*?)" exists in the remote repo$/ do |branch_name|
+  assert { remote_git.heads.include?(branch_name) }
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,8 +17,8 @@ end
 
 Before do
   @aruba_timeout_seconds = case defined?(RUBY_ENGINE) && RUBY_ENGINE
-                           when 'jruby' then 30
-                           when 'rbx' then 15
-                           else 5
+                           when 'jruby' then 45
+                           when 'rbx' then 30
+                           else 30
                            end
 end

--- a/features/support/minigit.rb
+++ b/features/support/minigit.rb
@@ -24,6 +24,10 @@ module Vendorificator
       def git
         @git ||= ::MiniGit::Capturing.new(current_dir)
       end
+
+      def remote_git
+        @remote_git ||= ::MiniGit::Capturing.new(current_dir + '/../remote-repository')
+      end
     end
   end
 end

--- a/lib/vendorificator/cli.rb
+++ b/lib/vendorificator/cli.rb
@@ -98,6 +98,14 @@ module Vendorificator
       fail! 'Repository is not clean.'
     end
 
+    desc :push, "Push local changes back to the remote repository"
+    method_option :remote, :aliases => ['-r'], :default => nil
+    def push
+      environment.push options
+    rescue DirtyRepoError
+      fail! 'Repository is not clean.'
+    end
+
     desc "git GIT_COMMAND [GIT_ARGS [...]]",
          "Run a git command for specified modules"
     long_desc <<EOF

--- a/lib/vendorificator/environment.rb
+++ b/lib/vendorificator/environment.rb
@@ -99,9 +99,15 @@ module Vendorificator
 
     # Public: Push changes to all remotes.
     #
+    # options - The Hash containing options
+    #
     # Returns nothing.
     def push(options = {})
-      git.push :all => true
+      ensure_clean!
+      remotes = options[:remote] ? options[:remote].split(',') : config[:remotes]
+      each_vendor_instance do |mod|
+        mod.push remotes
+      end
       git.push :tags => true
     end
 

--- a/lib/vendorificator/environment.rb
+++ b/lib/vendorificator/environment.rb
@@ -106,17 +106,10 @@ module Vendorificator
       ensure_clean!
 
       pushable = []
-      each_vendor_instance do |mod|
-        pushable << {:branch => mod.branch_name, :tag => mod.tag_name}
-      end
+      each_vendor_instance{ |mod| pushable += mod.pushable_refs }
 
       remotes = options[:remote] ? options[:remote].split(',') : config[:remotes]
-      remotes.each do |remote|
-        branches = pushable.map do |b|
-          ["+refs/heads/#{b[:branch]}", "+refs/tags/#{b[:tag]}"]
-        end.flatten
-        git.push remote, branches
-      end
+      remotes.each{ |remote| git.push remote, pushable }
 
       git.push :tags => true
     end

--- a/lib/vendorificator/environment.rb
+++ b/lib/vendorificator/environment.rb
@@ -97,6 +97,14 @@ module Vendorificator
       end
     end
 
+    # Public: Push changes to all remotes.
+    #
+    # Returns nothing.
+    def push(options = {})
+      git.push :all => true
+      git.push :tags => true
+    end
+
     # Public: Runs all the vendor modules.
     #
     # options - The Hash of options.

--- a/lib/vendorificator/vendor.rb
+++ b/lib/vendorificator/vendor.rb
@@ -139,12 +139,6 @@ module Vendorificator
       return :unknown
     end
 
-    def push(remotes)
-      remotes.each do |remote|
-        git.push remote, branch_name
-      end
-    end
-
     def needed?
       return self.status != :up_to_date
     end

--- a/lib/vendorificator/vendor.rb
+++ b/lib/vendorificator/vendor.rb
@@ -257,12 +257,24 @@ module Vendorificator
 
     def compute_dependencies! ; end
 
+    def pushable_refs
+      branch = "+refs/heads/#{branch_name}"
+      #tags = "+refs/tags/#{tag_name}"
+      tags = created_tags
+      [branch, tags]
+    end
+
     private
 
     def tagged_sha1
       @tagged_sha1 ||= git.capturing.rev_parse({:verify => true, :quiet => true}, "refs/tags/#{tag_name}^{commit}").strip
     rescue MiniGit::GitError
       nil
+    end
+
+    def created_tags
+      git.capturing.show_ref.split("\n").map{ |line| line.split(' ')[1] }.
+        select{ |ref| ref =~ /\Arefs\/tags/ }
     end
 
     def git

--- a/lib/vendorificator/vendor.rb
+++ b/lib/vendorificator/vendor.rb
@@ -259,9 +259,8 @@ module Vendorificator
 
     def pushable_refs
       branch = "+refs/heads/#{branch_name}"
-      #tags = "+refs/tags/#{tag_name}"
-      tags = created_tags
-      [branch, tags]
+      tags = created_tags.map{ |tag| '+' + tag }
+      [branch, tags].flatten
     end
 
     private
@@ -274,7 +273,7 @@ module Vendorificator
 
     def created_tags
       git.capturing.show_ref.split("\n").map{ |line| line.split(' ')[1] }.
-        select{ |ref| ref =~ /\Arefs\/tags/ }
+        select{ |ref| ref =~ /\Arefs\/tags\/#{tag_name_base}/ }
     end
 
     def git

--- a/lib/vendorificator/vendor.rb
+++ b/lib/vendorificator/vendor.rb
@@ -162,6 +162,12 @@ module Vendorificator
       return :unknown
     end
 
+    def push(remotes)
+      remotes.each do |remote|
+        environment.git.push remote, branch_name
+      end
+    end
+
     def needed?
       return self.status != :up_to_date
     end

--- a/lib/vendorificator/vendor/chef_cookbook.rb
+++ b/lib/vendorificator/vendor/chef_cookbook.rb
@@ -1,6 +1,6 @@
 require 'net/http'
 require 'uri'
-require 'multi_json'
+autoload :MultiJson, 'multi_json'
 
 require 'vendorificator/vendor/archive'
 require 'vendorificator/hooks/chef_cookbook'

--- a/vendorificator.gemspec
+++ b/vendorificator.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'escape'
   gem.add_dependency 'thor', '>= 0.18.1'
   gem.add_dependency 'minigit', '>= 0.0.3'
-  gem.add_dependency 'multi_json', '>= 1.7.1'
 
   gem.add_development_dependency 'aruba'
   gem.add_development_dependency 'cucumber'

--- a/vendorificator.gemspec
+++ b/vendorificator.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'thor', '>= 0.18.1'
   gem.add_dependency 'minigit', '>= 0.0.3'
 
-  gem.add_development_dependency 'aruba'
+  gem.add_development_dependency 'aruba', '0.5.1'
   gem.add_development_dependency 'cucumber'
   gem.add_development_dependency 'mocha'
   gem.add_development_dependency 'chef', '>= 10.16.0' unless defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'

--- a/vendorificator.gemspec
+++ b/vendorificator.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'escape'
   gem.add_dependency 'thor', '>= 0.18.1'
   gem.add_dependency 'minigit', '>= 0.0.3'
+  gem.add_dependency 'multi_json', '>= 1.7.1'
 
   gem.add_development_dependency 'aruba'
   gem.add_development_dependency 'cucumber'


### PR DESCRIPTION
Here's implementation for `vendor push`. It currently just does git push --all and git push --tags. 
This will change when we add notes with repository state information.

Also, it adds multi_json as runtime dependency, as it was missing.
