### PR TITLE
[don't merge me bro] Silencing side effects

### DIFF
--- a/features/tool.feature
+++ b/features/tool.feature
@@ -11,7 +11,7 @@ Background:
     tool 'bundler',
          :path => 'cache', # Hardcoded, meh
          :specs => [ 'Gemfile', 'Gemfile.lock' ],
-         :command => 'bundle package --all'
+         :command => 'bundle package --all > /dev/null'
     """
 
 Scenario: Use Gem bundler to download rubygems, and Vendorificator to vendor them

--- a/lib/vendorificator/environment.rb
+++ b/lib/vendorificator/environment.rb
@@ -133,9 +133,9 @@ module Vendorificator
 
       remotes = options[:remote] ? options[:remote].split(',') : config[:remotes]
       remotes.each do |remote|
-        git.push remote, pushable
-        git.push remote, :tags => true
-        git.push remote, 'refs/notes/vendor'
+        git.push remote, pushable, quiet: true
+        git.push remote, tags: true, quiet: true
+        git.push remote, 'refs/notes/vendor', quiet: true
       end
     end
 

--- a/lib/vendorificator/vendor.rb
+++ b/lib/vendorificator/vendor.rb
@@ -165,9 +165,9 @@ module Vendorificator
       Dir.mktmpdir("vendor-#{category}-#{name}") do |tmpdir|
         clone_opts = {:shared => true, :no_checkout => true}
         clone_opts[:branch] = branch_name if branch_exists
-        MiniGit.git(:clone, clone_opts, git.git_dir, tmpdir)
+        MiniGit::Capturing.git(:clone, clone_opts, git.git_dir, tmpdir)
         tmpgit = MiniGit::new(tmpdir)
-        tmpgit.checkout({orphan: true}, branch_name) unless branch_exists
+        tmpgit.checkout({orphan: true}, branch_name, {quiet: true}) unless branch_exists
         tmpgit.rm( { :r => true, :f => true, :q => true, :ignore_unmatch => true }, '.') if options[:clean] || !branch_exists
 
         begin
@@ -179,9 +179,9 @@ module Vendorificator
           @git = nil
         end
 
-        git.fetch(tmpdir)
-        git.fetch({tags: true}, tmpdir)
-        git.fetch(tmpdir,
+        git.fetch({quiet: true}, tmpdir)
+        git.fetch({tags: true, quiet: true}, tmpdir)
+        git.fetch({quiet: true}, tmpdir,
           "+refs/heads/#{branch_name}:refs/heads/#{branch_name}",
           "+refs/notes/vendor:refs/notes/vendor")
       end

--- a/lib/vendorificator/vendor/git.rb
+++ b/lib/vendorificator/vendor/git.rb
@@ -8,13 +8,13 @@ module Vendorificator
 
     def conjure!
       shell.say_status :clone, repository
-      MiniGit.git :clone, repository, '.'
+      MiniGit.git :clone, repository, '.', quiet: true
       local_git = MiniGit.new('.')
 
       if tag||revision
-        local_git.checkout({:b => 'vendorified'}, tag||revision)
+        local_git.checkout({:b => 'vendorified'}, tag||revision, quiet: true)
       elsif branch
-        local_git.checkout({:b => 'vendorified'}, "origin/#{branch}")
+        local_git.checkout({:b => 'vendorified'}, "origin/#{branch}", quiet: true)
       end
 
       super

--- a/lib/vendorificator/vendor/tool.rb
+++ b/lib/vendorificator/vendor/tool.rb
@@ -18,8 +18,7 @@ module Vendorificator
         src = File.join(environment.git.git_work_tree, spec)
         if File.exist?(src)
           FileUtils.install File.join(environment.git.git_work_tree, spec),
-                            File.join(git.git_work_tree, spec),
-                            verbose: true
+                            File.join(git.git_work_tree, spec)
         end
         Dir.chdir(git.git_work_tree) do
           system self.command or raise RuntimeError, "Command failed"
@@ -47,14 +46,14 @@ module Vendorificator
       tool 'rubygems',
            :path => 'cache', # Hardcoded, meh
            :specs => [ 'Gemfile', 'Gemfile.lock' ],
-           :command => 'bundle package --all'
+           :command => 'bundle package --all > /dev/null'
     end
 
     def chef_berkshelf
       tool 'cookbooks',
            :path => 'cookbooks',
            :specs => [ 'Berksfile', 'Berksfile.lock' ],
-           :command => 'berks install --path vendor/cookbooks'
+           :command => 'berks install --quiet --path vendor/cookbooks'
     end
   end
 end


### PR DESCRIPTION
That's a rough bunch of commits that silences output we get in the cucumber tests. It was annoying, so I silenced it all. 

However, it would be nice to keep the berkshelf and bundler output, maybe redirect them to a log file? Maybe redirect the git diff/merge information as well?

Or maybe just silence it for cucumber tests. We're capturing STDOUT anyway, so probably there's a way we could send it to /dev/null just for tests.
