### PR TITLE
Handle missing notes

### DIFF
--- a/lib/vendorificator/cli.rb
+++ b/lib/vendorificator/cli.rb
@@ -29,7 +29,6 @@ module Vendorificator
       :banner => 'mod1,mod2,...,modN',
       :desc => 'Run only for specified modules (name or path, comma separated)'
     class_option :version,                   :type => :boolean
-    class_option :help,    :aliases => '-h', :type => :boolean
 
     def initialize(args=[], options={}, config={})
       super
@@ -40,11 +39,6 @@ module Vendorificator
 
       if self.options[:version]
         say "Vendorificator #{Vendorificator::VERSION}"
-        exit
-      end
-
-      if self.options[:help] && config[:current_task].name != 'help'
-        invoke :help, [ config[:current_task].name ]
         exit
       end
 

--- a/lib/vendorificator/environment.rb
+++ b/lib/vendorificator/environment.rb
@@ -68,7 +68,7 @@ module Vendorificator
 
       git.fetch(remote)
       git.fetch({:tags => true}, remote)
-      git.fetch(remote, 'refs/notes/vendor:refs/notes/vendor')
+      git.fetch(remote, 'refs/notes/vendor:refs/notes/vendor') rescue MiniGit::GitError
 
       ref_rx = /^refs\/remotes\/#{Regexp.quote(remote)}\//
       remote_branches = Hash[ git.capturing.show_ref.

--- a/lib/vendorificator/environment.rb
+++ b/lib/vendorificator/environment.rb
@@ -143,13 +143,7 @@ module Vendorificator
       pushable = []
       each_vendor_instance { |mod| pushable += mod.pushable_refs }
 
-      has_notes = begin
-                    git.capturing.rev_parse({:quiet => true, :verify => true}, 'refs/notes/vendor')
-                    true
-                  rescue MiniGit::GitError
-                    false
-                  end
-      pushable << 'refs/notes/vendor' if has_notes
+      pushable << 'refs/notes/vendor' if has_notes?
 
       remotes = options[:remote] ? options[:remote].split(',') : config[:remotes]
       remotes.each do |remote|
@@ -288,6 +282,16 @@ module Vendorificator
       yield
     ensure
       shell.padding -= 1 if shell
+    end
+
+    # Private: Checks if there are git vendor notes.
+    #
+    # Returns true/false.
+    def has_notes?
+      git.capturing.rev_parse({:quiet => true, :verify => true}, 'refs/notes/vendor')
+      true
+    rescue MiniGit::GitError
+      false
     end
   end
 end

--- a/lib/vendorificator/environment.rb
+++ b/lib/vendorificator/environment.rb
@@ -135,7 +135,7 @@ module Vendorificator
       remotes.each do |remote|
         git.push remote, pushable
         git.push remote, :tags => true
-        git.push remote, 'refs/notes/vendor'
+        git.push remote, 'refs/notes/vendor' rescue MiniGit::GitError
       end
     end
 

--- a/lib/vendorificator/environment.rb
+++ b/lib/vendorificator/environment.rb
@@ -132,13 +132,19 @@ module Vendorificator
       ensure_clean!
 
       pushable = []
-      each_vendor_instance{ |mod| pushable += mod.pushable_refs }
+      each_vendor_instance { |mod| pushable += mod.pushable_refs }
+
+      has_notes = begin
+                    git.capturing.rev_parse({:quiet => true, :verify => true}, 'refs/notes/vendor')
+                    true
+                  rescue MiniGit::GitError
+                    false
+                  end
+      pushable << 'refs/notes/vendor' if has_notes
 
       remotes = options[:remote] ? options[:remote].split(',') : config[:remotes]
       remotes.each do |remote|
         git.push remote, pushable
-        git.push remote, :tags => true
-        git.push remote, 'refs/notes/vendor' rescue MiniGit::GitError
       end
     end
 

--- a/lib/vendorificator/environment.rb
+++ b/lib/vendorificator/environment.rb
@@ -68,7 +68,10 @@ module Vendorificator
 
       git.fetch(remote)
       git.fetch({:tags => true}, remote)
-      git.fetch(remote, 'refs/notes/vendor:refs/notes/vendor') rescue MiniGit::GitError
+      begin
+        git.fetch(remote, 'refs/notes/vendor:refs/notes/vendor')
+      rescue MiniGit::GitError  # ignore
+      end
 
       ref_rx = /^refs\/remotes\/#{Regexp.quote(remote)}\//
       remote_branches = Hash[ git.capturing.show_ref.

--- a/lib/vendorificator/vendor.rb
+++ b/lib/vendorificator/vendor.rb
@@ -252,9 +252,7 @@ module Vendorificator
     def compute_dependencies! ; end
 
     def pushable_refs
-      created_tags.
-        map { |tag| '+' << tag }.
-        unshift("+refs/heads/#{branch_name}")
+      created_tags.unshift("refs/heads/#{branch_name}")
     end
 
     def metadata

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,8 +44,9 @@ class MiniTest::Spec
   include Vendorificator::Spec::Helpers::Wrong
 
   before do
-    _git = stub
-    _git.stubs(:capturing).returns(stub)
+    _git = stub('git')
+    _capturing = stub('git.capturing')
+    _git.stubs(:capturing).returns(_capturing)
     Vendorificator::Environment.any_instance.stubs(:git).returns(_git)
   end
 

--- a/spec/vendorificator/environment_spec.rb
+++ b/spec/vendorificator/environment_spec.rb
@@ -64,6 +64,20 @@ module Vendorificator
       end
     end
 
+    describe '#push' do
+      it "handles git error on pushing empty notes" do
+        environment.unstub(:git)
+        environment.stubs(:ensure_clean!)
+        environment.vendor_instances = []
+
+        environment.git.stubs(:push).with('origin', [])
+        environment.git.stubs(:push).with('origin', :tags => true)
+        environment.git.expects(:push).with('origin', 'refs/notes/vendor').raises(MiniGit::GitError)
+
+        environment.push(:remote => 'origin')
+      end
+    end
+
     describe '#vendor_instances' do
       let(:environment){ Environment.new 'spec/vendorificator/fixtures/vendorfiles/empty_vendor.rb' }
 

--- a/spec/vendorificator/environment_spec.rb
+++ b/spec/vendorificator/environment_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 module Vendorificator
   describe Environment do
+    let(:environment) { Environment.new 'spec/vendorificator/fixtures/vendorfiles/vendor.rb' }
     before do
-      MiniGit.any_instance.stubs(:fetch)
+      environment.git.capturing.stubs(:remote).returns("origin\n")
     end
-    let(:environment){ Environment.new 'spec/vendorificator/fixtures/vendorfiles/vendor.rb' }
 
     describe '#clean' do
       it 'returns false for dirty repo' do
@@ -41,32 +41,32 @@ module Vendorificator
     end
 
     describe '#pull' do
+      before do
+        environment.git.expects(:fetch).with('origin')
+        environment.git.expects(:fetch).with({:tags => true}, 'origin')
+        @git_fetch_notes = environment.git.expects(:fetch).with('origin', 'refs/notes/vendor:refs/notes/vendor')
+        environment.git.capturing.stubs(:show_ref).returns("602315 refs/remotes/origin/vendor/test\n")
+        environment.vendor_instances = []
+      end
+
       it "creates a branch if it doesn't exist" do
-        Environment.any_instance.unstub(:git)
-        environment.git.capturing.stubs(:show_ref).
-          returns("602315 refs/remotes/origin/vendor/test")
-        environment.vendor_instances = [ stub(:branch_name => 'vendor/test', :head => nil)]
+        environment.vendor_instances << stub(:branch_name => 'vendor/test', :head => nil)
 
         environment.git.expects(:branch).with({:track => true}, 'vendor/test', '602315')
+
         environment.pull('origin')
       end
 
       it "handles fast forwardable branches" do
-        Environment.any_instance.unstub(:git)
-        environment.git.capturing.stubs(:show_ref).
-          returns("602315 refs/remotes/origin/vendor/test")
-        environment.vendor_instances = [stub(
-          :branch_name => 'vendor/test', :head => '123456', :in_branch => true, :name => 'test'
-        )]
-
+        environment.vendor_instances << stub(
+          :branch_name => 'vendor/test', :head => '123456', :in_branch => true, :name => 'test')
         environment.expects(:fast_forwardable?).returns(true)
+
         environment.pull('origin')
       end
 
       it "handles git error on fetching empty notes" do
-        Environment.any_instance.unstub(:git)
-        MiniGit.any_instance.expects(:fetch).with('origin', 'refs/notes/vendor:refs/notes/vendor').
-          raises(MiniGit::GitError)
+        @git_fetch_notes.raises(MiniGit::GitError)
 
         environment.pull('origin')
       end
@@ -74,13 +74,23 @@ module Vendorificator
 
     describe '#push' do
       it "handles git error on pushing empty notes" do
-        environment.unstub(:git)
         environment.stubs(:ensure_clean!)
         environment.vendor_instances = []
 
-        environment.git.stubs(:push).with('origin', [])
+        environment.git.capturing.expects(:rev_parse).with({:quiet => true, :verify => true}, 'refs/notes/vendor').raises(MiniGit::GitError)
+        environment.git.expects(:push).with('origin', [])
         environment.git.stubs(:push).with('origin', :tags => true)
-        environment.git.expects(:push).with('origin', 'refs/notes/vendor').raises(MiniGit::GitError)
+
+        environment.push(:remote => 'origin')
+      end
+
+      it "pushes note when they exist" do
+        environment.stubs(:ensure_clean!)
+        environment.vendor_instances = []
+
+        environment.git.capturing.expects(:rev_parse).with({:quiet => true, :verify => true}, 'refs/notes/vendor').returns('abcdef')
+        environment.git.expects(:push).with('origin', ['refs/notes/vendor'])
+        environment.git.stubs(:push).with('origin', :tags => true)
 
         environment.push(:remote => 'origin')
       end

--- a/spec/vendorificator/environment_spec.rb
+++ b/spec/vendorificator/environment_spec.rb
@@ -62,6 +62,14 @@ module Vendorificator
         environment.expects(:fast_forwardable?).returns(true)
         environment.pull('origin')
       end
+
+      it "handles git error on fetching empty notes" do
+        Environment.any_instance.unstub(:git)
+        MiniGit.any_instance.expects(:fetch).with('origin', 'refs/notes/vendor:refs/notes/vendor').
+          raises(MiniGit::GitError)
+
+        environment.pull('origin')
+      end
     end
 
     describe '#push' do

--- a/spec/vendorificator/vendor_spec.rb
+++ b/spec/vendorificator/vendor_spec.rb
@@ -119,18 +119,18 @@ EOF
 
       it 'includes all own refs' do
         refs = environment['nginx'].pushable_refs
-        assert { refs.include? '+refs/heads/vendor/cookbooks/nginx' }
-        assert { refs.include? '+refs/tags/vendor/cookbooks/nginx/1.2.0' }
-        assert { refs.include? '+refs/tags/vendor/cookbooks/nginx/1.3.0' }
+        assert { refs.include? 'refs/heads/vendor/cookbooks/nginx' }
+        assert { refs.include? 'refs/tags/vendor/cookbooks/nginx/1.2.0' }
+        assert { refs.include? 'refs/tags/vendor/cookbooks/nginx/1.3.0' }
 
         refs = environment['nginx_simplecgi'].pushable_refs
-        assert { refs.include? '+refs/heads/vendor/cookbooks/nginx_simplecgi' }
-        assert { refs.include? '+refs/tags/vendor/cookbooks/nginx_simplecgi/0.1.0' }
+        assert { refs.include? 'refs/heads/vendor/cookbooks/nginx_simplecgi' }
+        assert { refs.include? 'refs/tags/vendor/cookbooks/nginx_simplecgi/0.1.0' }
       end
 
       it "doesn't include other modules' refs" do
         refs = environment['nginx'].pushable_refs
-        deny { refs.include? '+refs/tags/vendor/cookbooks/nginx_simplecgi/0.1.0' }
+        deny { refs.include? 'refs/tags/vendor/cookbooks/nginx_simplecgi/0.1.0' }
       end
     end
   end


### PR DESCRIPTION
We still get ominous output from a failed push/pull, but we'll handle that when capturing stderr output in minigit. 
