### PR TITLE
Running vendor help without a Vendorfile present.

### DIFF
--- a/lib/vendorificator/cli.rb
+++ b/lib/vendorificator/cli.rb
@@ -48,8 +48,10 @@ module Vendorificator
         exit
       end
 
-      @environment = Vendorificator::Environment.new(self.options[:file])
-      environment.shell = shell
+      unless config[:current_command].name == 'help'
+        @environment = Vendorificator::Environment.new(self.options[:file])
+        environment.shell = shell
+      end
 
       class << shell
         # Make say_status always say it.


### PR DESCRIPTION
This change allows to run help commands (vendor, vendor help, vendor help push, etc.) without creating a Vendorfile.
